### PR TITLE
Add quartus 18.1 lite

### DIFF
--- a/pkgs/altera-quartus/default.nix
+++ b/pkgs/altera-quartus/default.nix
@@ -63,8 +63,11 @@ in rec {
   altera-quartus-prime-lite-18 =
     mkCommonQuartus sources.v18.lite_edition;
 
+  altera-quartus-prime-standard-18 =
+    mkCommonQuartus sources.v18.standard_edition;
+
   # Aliases to latest versions
   altera-quartus-prime-lite = altera-quartus-prime-lite-18;
-  altera-quartus-prime-standard = altera-quartus-prime-standard-16;
+  altera-quartus-prime-standard = altera-quartus-prime-standard-18;
 
 }

--- a/pkgs/altera-quartus/default.nix
+++ b/pkgs/altera-quartus/default.nix
@@ -2,7 +2,7 @@
 , nukeReferences, glibcLocales, libfaketime, coreutils, gnugrep, gnused, proot
 # Runtime libraries:
 , zlib, glib, libpng12, freetype, libSM, libICE, libXrender, fontconfig
-, libXext, libX11, libXtst, gtk2, bzip2, libelf
+, libXext, libX11, libXtst, libXi, gtk2, bzip2, libelf
 }:
 
 let
@@ -15,19 +15,21 @@ let
       nukeReferences glibcLocales libfaketime coreutils gnugrep gnused proot
       # Runtime libraries:
       zlib glib libpng12 freetype libSM libICE libXrender fontconfig
-      libXext libX11 libXtst gtk2 bzip2 libelf;
+      libXext libX11 libXtst libXi gtk2 bzip2 libelf;
   };
 
   mkCommonQuartus = srcAttrs:
     buildQuartus {
       inherit (srcAttrs) baseName prettyName is32bitPackage;
-      version = srcAttrs.updates.version;
+      # If the package doens't have any updates, use the base version
+      version = srcAttrs.updates.version or srcAttrs.version;
       components = with srcAttrs.components; [
         quartus cyclonev
       ];
-      updateComponents = with srcAttrs.updates.components; [
-        quartus
-      ];
+      updateComponents =
+        stdenv.lib.optional
+          (stdenv.lib.hasAttr "updates" srcAttrs)
+          srcAttrs.updates.components.quartus;
     };
 
 in rec {
@@ -58,8 +60,11 @@ in rec {
   altera-quartus-prime-standard-16 =
     mkCommonQuartus sources.v16.standard_edition;
 
+  altera-quartus-prime-lite-18 =
+    mkCommonQuartus sources.v18.lite_edition;
+
   # Aliases to latest versions
-  altera-quartus-prime-lite = altera-quartus-prime-lite-16;
+  altera-quartus-prime-lite = altera-quartus-prime-lite-18;
   altera-quartus-prime-standard = altera-quartus-prime-standard-16;
 
 }

--- a/pkgs/altera-quartus/generic.nix
+++ b/pkgs/altera-quartus/generic.nix
@@ -425,7 +425,6 @@ stdenv.mkDerivation rec {
             maybe_proot_cmd="proot -b ${bash}/bin/sh:/bin/sh"
             # Work around bug with linux 4.8.4+ (costs some performance, but
             # prevents breakage).
-            export PROOT_NO_SECCOMP=1
         fi
         # Prepare LD_LIBRARY_PATH, LD_PRELOAD
         if [ "x\$LD_LIBRARY_PATH" != x ]; then

--- a/pkgs/altera-quartus/generic.nix
+++ b/pkgs/altera-quartus/generic.nix
@@ -378,8 +378,7 @@ stdenv.mkDerivation rec {
     {
         dest="$out/bin/$(basename "$1")"
         if [ -f "$dest" ]; then
-            echo "ERROR: $dest already exist"
-            exit 1
+            echo "WARNING: $dest already exists"
         fi
         cat > "$dest" << EOF
     #!${bash}/bin/sh
@@ -459,7 +458,7 @@ stdenv.mkDerivation rec {
 
     echo "Creating top-level bin/ directory with wrappers for common tools"
     mkdir -p "$out/bin"
-    for p in "${quartusUnwrapped}/"*"/bin/"*; do
+    for p in "${quartusUnwrapped}/"*"/bin/"* "${quartusUnwrapped}/quartus/sopc_builder/bin/"*; do
         test -f "$p" || continue
         wrap "$p"
     done

--- a/pkgs/altera-quartus/generic.nix
+++ b/pkgs/altera-quartus/generic.nix
@@ -369,7 +369,7 @@ stdenv.mkDerivation rec {
   name = "${baseName}-${version}";
   # version and srcs are unused by this derivation, but keep them as metadata
   # (for users).
-  inherit (quartusUnwrapped) version srcs;
+  inherit (quartusUnwrapped) version;
   buildCommand = ''
     # Provide convenience wrappers in $out/bin, so that the tools can be
     # started directly from PATH. Plain symlinks don't work, due to assumptions
@@ -478,6 +478,10 @@ stdenv.mkDerivation rec {
     Path=$out
     EOF
   '';
+
+  passthru = {
+    unwrapped = quartusUnwrapped;
+  };
 
   meta = with stdenv.lib; {
     description = "Development tools for Altera FPGA, CPLD and SoC designs";

--- a/pkgs/altera-quartus/generic.nix
+++ b/pkgs/altera-quartus/generic.nix
@@ -444,6 +444,8 @@ stdenv.mkDerivation rec {
         # Set the time to SOURCE_DATE_EPOCH
         export FAKETIME_FMT="%s"
         export FAKETIME=\$(date +%s -d @\$SOURCE_DATE_EPOCH)
+        # Stop Java applications from hanging
+        export DONT_FAKE_MONOTONIC=1
     fi
 
     # Fix this:

--- a/pkgs/altera-quartus/sources.nix
+++ b/pkgs/altera-quartus/sources.nix
@@ -596,4 +596,31 @@ rec {
 
   };
 
+  v18 = rec {
+    recurseForDerivations = true;
+    version = "18.1.0.625";
+    is32bitPackage = false;
+    baseUrl = "http://download.altera.com/akdlm/software/acdsinst/18.1std/625/ib_installers";
+
+    lite_edition = {
+      recurseForDerivations = true;
+      baseName = "altera-quartus-prime-lite";
+      prettyName = "Quartus Prime Lite Edition";
+      inherit version is32bitPackage;
+      components = {
+        recurseForDerivations = true;
+        quartus = fetchurl {
+          # Size: 2.0 GB MD5: 75F5029A9058F64F969496B016EE19D4
+          url = "${baseUrl}/QuartusLiteSetup-${version}-linux.run";
+          sha256 = "04smqi5njlgjwal87xc80dji79w78hvdd4kz80chfac6bzv7bn86";
+        };
+        cyclonev = fetchurl {
+          # Size: 1.1 GB MD5: 8386E6891D17DC1FAF29067C46953FC7
+          url = "${baseUrl}/cyclonev-${version}.qdz";
+          sha256 = "0ab38m648cwp95yd0f7xlnhmvqjg9yrls94xigxxmadixs8r9y03";
+        };
+      };
+    };
+  };
+
 }

--- a/pkgs/altera-quartus/sources.nix
+++ b/pkgs/altera-quartus/sources.nix
@@ -621,6 +621,24 @@ rec {
         };
       };
     };
+    standard_edition = {
+      recurseForDerivations = true;
+      baseName = "altera-quartus-prime-standard";
+      prettyName = "Quartus Prime Standard Edition";
+      inherit version is32bitPackage;
+      components = {
+        recurseForDerivations = true;
+        quartus = fetchurl {
+          # Size: 2.7 GB MD5: 7D26DB3BB0ED8EAB62D30FDA4EE316B1
+          url = "${baseUrl}/QuartusSetup-${version}-linux.run";
+          sha256 = "13racbf0x4lb501nqc7crnn0yjl4j7z8bqj6qv9ss3mhdcr5dcp5";
+        };
+        cyclonev = fetchurl {
+          # Size: 1.1 GB MD5: 75F5029A9058F64F969496B016EE19D4
+          url = "${baseUrl}/cyclonev-${version}.qdz";
+          sha256 = "0ab38m648cwp95yd0f7xlnhmvqjg9yrls94xigxxmadixs8r9y03";
+        };
+      };
+    };
   };
-
 }


### PR DESCRIPTION
**This isn't quite ready for a merge yet**, I've not tested it with older versions of quartus, and have only added the minimal sources to get quartus lite working. I'm opening the PR just to keep track of things and stop it getting lost :) Hopefully this can be merged when I've had a change to complete and clean things up

This requires a few changes to the build script.

- libXi is a new dependency, required for qsys to run
- Quartus 18.1 has no updates at the moment, so make the build script accomodate that
- Quartus 18.1 works with glibc 2.25, so no need to use an older version
- Quartus 18.1 required `--accept_eula 1` passed to the installer
- Work around https://github.com/NixOS/nixpkgs/issues/41729 by using readelf instead of file to determine if a file is an executable or a shared object